### PR TITLE
✨ Avatarキャッシュ更新機能の追加と画像キャッシュ改善

### DIFF
--- a/AvatarManager.Core/Services/AvatarService.cs
+++ b/AvatarManager.Core/Services/AvatarService.cs
@@ -56,4 +56,14 @@ public class AvatarService : IAvatarService
         }
         return null;
     }
+
+    public async Task UpdateCachedAvatarAsync(OwnedAvatar avatar,  string newImagePath)
+    {
+        var current = await _dbContext.OwnedAvatars.FirstOrDefaultAsync(x => x.Id == avatar.Id);
+        current.Name = avatar.Name;
+        current.ThumbnailImageUrl = avatar.ThumbnailImageUrl;
+        current.ImagePath = newImagePath;
+        _dbContext.OwnedAvatars.Update(current);
+        await _dbContext.SaveChangesAsync();
+    }
 }

--- a/AvatarManager.Core/Services/ImageService.cs
+++ b/AvatarManager.Core/Services/ImageService.cs
@@ -15,7 +15,7 @@ public class ImageService : IImageService
     public async Task<string> DownloadAndCacheImageAsync(string id, string url)
     {
         var response = await _vrcApi.DownloadImageAsync(url);
-        var path = Path.Combine(Directory.GetCurrentDirectory(), $"Data\\CachedImages\\{id}.png");
+        var path = Path.Combine(Directory.GetCurrentDirectory(), $"Data\\CachedImages\\{id}_{DateTime.Now.ToString("yyyyMMddhhmmss")}.png");
         if (response.IsSuccessStatusCode)
         {
             using (var fs = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite))

--- a/AvatarManager.Core/Services/interfaces/IAvatarService.cs
+++ b/AvatarManager.Core/Services/interfaces/IAvatarService.cs
@@ -8,4 +8,5 @@ public interface IAvatarService
     Task CacheAvatarAsync(OwnedAvatar avatar);
     Task<List<OwnedAvatar>> GetUnCategorizedAvatarsAsync();
     Task<List<OwnedAvatar>> GetAvatarsByFolderIdAsync(string folderId);
+    Task UpdateCachedAvatarAsync(OwnedAvatar avatar, string newImagePath);
 }

--- a/AvatarManager.WinForm/Forms/MainWindow.cs
+++ b/AvatarManager.WinForm/Forms/MainWindow.cs
@@ -169,7 +169,7 @@ public partial class MainWindow : Form
         if (folder == null)
         {
             var avatars = await _avatarService.GetUnCategorizedAvatarsAsync();
-            foreach(var a in avatars)
+            foreach (var a in avatars)
             {
                 var i = avatarGrid.Rows.Add(new Bitmap(a.ImagePath), a.Name, a.Id);
                 avatarGrid.Rows[i].Height = 70;
@@ -220,6 +220,23 @@ public partial class MainWindow : Form
         foreach (var c in cachedAvatars)
         {
             var a = avatars.FirstOrDefault(x => x.Id == c.Id);
+            if (a == null)
+            {
+                continue;
+            }
+            // update cached avatar
+            if (a.Name != c.Name || a.ThumbnailImageUrl != c.ThumbnailImageUrl)
+            {
+                await _avatarService.UpdateCachedAvatarAsync(
+                    new OwnedAvatar
+                    {
+                        Id = a.Id,
+                        Name = a.Name,
+                        ThumbnailImageUrl = a.ThumbnailImageUrl
+                    },
+                    await _imageService.DownloadAndCacheImageAsync(a.Id, a.ThumbnailImageUrl));
+            }
+
             avatars.Remove(a);
         }
 


### PR DESCRIPTION
- `AvatarService.cs` に `UpdateCachedAvatarAsync` メソッドを追加
  - 指定された `OwnedAvatar` オブジェクトの情報を更新し、新しい画像パスを設定
- `ImageService.cs` の `DownloadAndCacheImageAsync` メソッドを変更
  - キャッシュされた画像のファイル名にタイムスタンプを追加し、同じIDの画像が上書きされるのを防止
- `IAvatarService.cs` に `UpdateCachedAvatarAsync` メソッドの宣言を追加
  - `IAvatarService` インターフェースを実装するクラスはこのメソッドを実装する必要あり
- `MainWindow.cs` の `GetUnCategorizedAvatarsAsync` メソッド呼び出し部分の `foreach` ループのフォーマットを修正
- `MainWindow.cs` にキャッシュされたアバター情報を更新するロジックを追加
  - キャッシュされたアバターの名前やサムネイル画像URLが変更された場合に `UpdateCachedAvatarAsync` メソッドを呼び出して更新