### PR TITLE
:sparkles: 未分類フォルダが選択されている状態で右クリックを無効化

### DIFF
--- a/AvatarManager.WinForm/Forms/MainWindow.Designer.cs
+++ b/AvatarManager.WinForm/Forms/MainWindow.Designer.cs
@@ -162,19 +162,20 @@
             folderRightClickMenu.Items.AddRange(new ToolStripItem[] { editMenuItem, deleteMenuItem });
             folderRightClickMenu.Name = "contextMenuStrip1";
             folderRightClickMenu.RenderMode = ToolStripRenderMode.System;
-            folderRightClickMenu.Size = new Size(99, 48);
+            folderRightClickMenu.Size = new Size(181, 70);
+            folderRightClickMenu.Opening += folderRightClickMenu_Opening;
             // 
             // editMenuItem
             // 
             editMenuItem.Name = "editMenuItem";
-            editMenuItem.Size = new Size(98, 22);
+            editMenuItem.Size = new Size(180, 22);
             editMenuItem.Text = "編集";
             editMenuItem.Click += editMenuItem_Click;
             // 
             // deleteMenuItem
             // 
             deleteMenuItem.Name = "deleteMenuItem";
-            deleteMenuItem.Size = new Size(98, 22);
+            deleteMenuItem.Size = new Size(180, 22);
             deleteMenuItem.Text = "削除";
             deleteMenuItem.Click += deleteMenuItem_Click;
             // 

--- a/AvatarManager.WinForm/Forms/MainWindow.cs
+++ b/AvatarManager.WinForm/Forms/MainWindow.cs
@@ -108,6 +108,7 @@ public partial class MainWindow : Form
         form.ShowDialog();
 
         // update folder grid
+        currentFolderIndex = 0;
         folderGrid.Rows.Clear();
         await GenerateFolderGridAsync();
     }
@@ -155,6 +156,20 @@ public partial class MainWindow : Form
         currentFolderIndex = 0;
         folderGrid.Rows.Clear();
         await GenerateFolderGridAsync();
+    }
+
+    /// <summary>
+    /// フォルダグリッドで右クリックメニューが開かれるときの処理
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
+    private void folderRightClickMenu_Opening(object sender, System.ComponentModel.CancelEventArgs e)
+    {
+        // 未分類を右クリックしたときは編集と削除を非表示
+        if (currentFolderIndex == folderGrid.RowCount - 1)
+        {
+            e.Cancel = true;
+        }
     }
     #endregion
 


### PR DESCRIPTION
- :bug: `MainWindow.cs` に `currentFolderIndex` を `0` にリセットするコードを追加
- :sparkles: `folderRightClickMenu_Opening` メソッドを追加し、右クリックメニューが開かれる際に、最後の行が選択されている場合はメニューをキャンセルするロジックを実装
