### PR TITLE
:bug: exeのパスが変わるとキャッシュした画像が読めず全ロードしなおしになる問題の修正

### DIFF
--- a/AvatarManager.Core/Services/ImageService.cs
+++ b/AvatarManager.Core/Services/ImageService.cs
@@ -15,7 +15,7 @@ public class ImageService : IImageService
     public async Task<string> DownloadAndCacheImageAsync(string id, string url)
     {
         var response = await _vrcApi.DownloadImageAsync(url);
-        var path = Path.Combine(Directory.GetCurrentDirectory(), $"Data\\CachedImages\\{id}_{DateTime.Now.ToString("yyyyMMddhhmmss")}.png");
+        var path = $"Data\\CachedImages\\{id}_{DateTime.Now.ToString("yyyyMMddhhmmss")}.png";
         if (response.IsSuccessStatusCode)
         {
             using (var fs = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite))


### PR DESCRIPTION
closes #65 